### PR TITLE
fix bug where placeholder cards duplicate

### DIFF
--- a/src/components/common/CityCard.js
+++ b/src/components/common/CityCard.js
@@ -56,6 +56,7 @@ const CityCard = props => {
 const mapStateToProps = state => {
   return {
     cities: state.cities,
+    comparingCities: state.comparingCities,
   }
 }
 

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -21,6 +21,7 @@ const Home = props => {
   }, [])
 
   const [state, setState] = useState(initialState)
+  const [comparisons, setComparisons] = useState([])
 
   const onChangeHandler = e => {
     setState({
@@ -29,6 +30,14 @@ const Home = props => {
     })
   }
 
+  useEffect(() => {
+    var compareIds = []
+    props.comparingCities.forEach(city => {
+      compareIds.push(city.cityId)
+      setComparisons(compareIds)
+    })
+  }, [props.comparingCities])
+
   props.cities.sort()
 
   return (
@@ -36,9 +45,13 @@ const Home = props => {
       <SearchBar onChangeHandler={onChangeHandler} initialState={state} />
 
       <div className="city-card-container">
-        {props.cities.map(city => {
-          return <CityCard key={city.id} city={city} compare={false} />
-        })}
+        {props.cities
+          .filter(city => {
+            return !comparisons.includes(city.cityId)
+          })
+          .map(city => {
+            return <CityCard key={city.id} city={city} compare={false} />
+          })}
       </div>
     </section>
   )
@@ -47,6 +60,7 @@ const Home = props => {
 const mapStateToProps = state => {
   return {
     cities: state.cities,
+    comparingCities: state.comparingCities,
   }
 }
 

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -15,27 +15,7 @@ const initialApplicationState = {
   compareErrorMessage: null,
   cities: [],
 
-  // comparingCities: {
-  //   cityOne: {},
-  //   cityTwo: {},
-  //   cityThree: {},
-  // },
-  comparingCities: [
-    {
-      cityName: 'Seattle, WA',
-      cityId: 20,
-      population: 3000000,
-      rentRate: 1500,
-      medIncome: 55000,
-    },
-    {
-      cityName: 'Seattle, WA',
-      cityId: 22,
-      population: 3000000,
-      rentRate: 1500,
-      medIncome: 55000,
-    },
-  ],
+  comparingCities: [],
 
   userPreferences: {
     favorites: [],


### PR DESCRIPTION
fix bug where placeholder cards duplicate if city is selected multiple times and deleted. filters out city on home page, when that city is in the compare footer to prevent multiple selections of the same city.